### PR TITLE
feat: MoodSelectorをMood APIと連携

### DIFF
--- a/components/MoodSelector.tsx
+++ b/components/MoodSelector.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { Button } from './ui/button';
 import { Card } from './ui/card';
-import { Heart, Sun, Cloud, Moon, Zap, Coffee, Star, Smile } from 'lucide-react';
+import * as LucideIcons from 'lucide-react';
+import { trpc } from '@/utils/trpc';
 
 interface MoodSelectorProps {
   selectedColor: string;
@@ -9,47 +12,60 @@ interface MoodSelectorProps {
   onIconChange: (icon: string) => void;
 }
 
-const MOOD_COLORS = [
-  { name: '幸せ', color: '#FFD700', label: '黄色（幸せ）' },
-  { name: '穏やか', color: '#87CEEB', label: '水色（穏やか）' },
-  { name: '情熱', color: '#FF6B6B', label: '赤色（情熱）' },
-  { name: '自然', color: '#98D8C8', label: '緑色（自然）' },
-  { name: '神秘', color: '#9B59B6', label: '紫色（神秘）' },
-  { name: '活力', color: '#FF8C00', label: 'オレンジ（活力）' },
-  { name: '憂鬱', color: '#708090', label: 'グレー（憂鬱）' },
-  { name: '愛情', color: '#FFB6C1', label: 'ピンク（愛情）' },
-];
-
-const MOOD_ICONS = [
-  { name: 'ハート', icon: 'Heart', component: Heart },
-  { name: '太陽', icon: 'Sun', component: Sun },
-  { name: '雲', icon: 'Cloud', component: Cloud },
-  { name: '月', icon: 'Moon', component: Moon },
-  { name: '雷', icon: 'Zap', component: Zap },
-  { name: 'コーヒー', icon: 'Coffee', component: Coffee },
-  { name: '星', icon: 'Star', component: Star },
-  { name: '笑顔', icon: 'Smile', component: Smile },
-];
+// Lucide Reactのアイコンコンポーネントを取得するヘルパー関数
+const getIconComponent = (iconName: string) => {
+  const icons = LucideIcons as unknown as Record<string, React.ComponentType<{ size?: number }>>;
+  return icons[iconName] || LucideIcons.Circle;
+};
 
 export function MoodSelector({ selectedColor, selectedIcon, onColorChange, onIconChange }: MoodSelectorProps) {
+  const { data: moods, isLoading, error } = trpc.mood.list.useQuery();
+
+  if (isLoading) {
+    return (
+      <Card className="p-6 space-y-6">
+        <div className="text-center text-gray-500">読み込み中...</div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-6 space-y-6">
+        <div className="text-center text-red-500">エラーが発生しました: {error.message}</div>
+      </Card>
+    );
+  }
+
+  if (!moods || moods.length === 0) {
+    return (
+      <Card className="p-6 space-y-6">
+        <div className="text-center text-gray-500">気分データがありません</div>
+      </Card>
+    );
+  }
+
+  // orderでソート
+  const sortedMoods = [...moods].sort((a, b) => a.order - b.order);
+
   return (
     <Card className="p-6 space-y-6">
       <div>
         <h3 className="mb-4">今日の気分の色を選んでください</h3>
         <div className="grid grid-cols-4 gap-3">
-          {MOOD_COLORS.map((mood) => (
+          {sortedMoods.map((mood) => (
             <Button
-              key={mood.color}
+              key={mood.id}
               variant={selectedColor === mood.color ? 'default' : 'outline'}
               onClick={() => onColorChange(mood.color)}
               className="h-16 w-full relative overflow-hidden"
-              style={{ 
+              style={{
                 backgroundColor: selectedColor === mood.color ? mood.color : 'transparent',
                 borderColor: mood.color,
                 borderWidth: '2px'
               }}
             >
-              <div 
+              <div
                 className="absolute inset-1 rounded opacity-30"
                 style={{ backgroundColor: mood.color }}
               />
@@ -62,11 +78,11 @@ export function MoodSelector({ selectedColor, selectedIcon, onColorChange, onIco
       <div>
         <h3 className="mb-4">気分を表すアイコンを選んでください</h3>
         <div className="grid grid-cols-4 gap-3">
-          {MOOD_ICONS.map((mood) => {
-            const IconComponent = mood.component;
+          {sortedMoods.map((mood) => {
+            const IconComponent = getIconComponent(mood.icon);
             return (
               <Button
-                key={mood.icon}
+                key={mood.id}
                 variant={selectedIcon === mood.icon ? 'default' : 'outline'}
                 onClick={() => onIconChange(mood.icon)}
                 className="h-16 aspect-square"

--- a/server/routers/_app.ts
+++ b/server/routers/_app.ts
@@ -1,10 +1,12 @@
 import { router } from "../trpc";
 import { userRouter } from "./user";
 import { diaryRouter } from "./diary";
+import { moodRouter } from "./mood";
 
 export const appRouter = router({
   user: userRouter,
-  diary: diaryRouter, // ←追加！
+  diary: diaryRouter,
+  mood: moodRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/routers/mood.ts
+++ b/server/routers/mood.ts
@@ -1,0 +1,12 @@
+import { prisma } from "../db";
+import { publicProcedure, router } from "../trpc";
+import { z } from "zod";
+
+export const moodRouter = router({
+  // 全気分データ取得
+  list: publicProcedure.query(async () => {
+    return await prisma.mood.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+  }),
+});


### PR DESCRIPTION
## Summary
- MoodSelector.tsxをハードコードされたデータからMood APIを使用した動的取得に変更

## 変更内容
- tRPC `mood.list` APIからmoodデータを取得
- ハードコードされた`MOOD_COLORS`と`MOOD_ICONS`を削除
- Lucide Reactアイコンの動的マッピング関数を実装
- ローディング状態、エラー状態、空データ状態の処理を追加
- `order`フィールドによる表示順ソート機能を実装
- TypeScript型エラーを修正（`as unknown as`による二段階型変換）

## 技術的変更
- `'use client'`ディレクティブを追加（React Hooks使用のため）
- `trpc.mood.list.useQuery()`でサーバーからデータを取得
- `getIconComponent()`関数でアイコン名から動的にコンポーネントを取得

## Test plan
- [ ] 開発サーバーを起動してMoodSelectorが正しく表示されることを確認
- [ ] データベースにmoodデータがある場合、それが表示されることを確認
- [ ] ローディング状態が適切に表示されることを確認
- [ ] エラー状態の処理が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)