### PR TITLE
feat: DiaryEntryにAPI保存機能を実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,8 +27,8 @@ export default function Page() {
   const [selectedEntry, setSelectedEntry] = useState<MoodEntry | null>(null);
   const [selectedDayEntries, setSelectedDayEntries] = useState<MoodEntry[]>([]);
 
-  const handleSaveEntry = (newEntry: MoodEntry) => {
-    // TODO: API経由で保存する実装が必要
+  const handleSaveSuccess = () => {
+    // 保存成功時に選択をクリア
     setSelectedColor('');
     setSelectedIcon('');
   };
@@ -84,7 +84,7 @@ export default function Page() {
               <DiaryEntry
                 selectedColor={selectedColor}
                 selectedIcon={selectedIcon}
-                onSave={handleSaveEntry}
+                onSave={handleSaveSuccess}
               />
             </div>
           </TabsContent>


### PR DESCRIPTION
## Summary
- DiaryEntry.tsxをAPI経由でバックエンドに保存できるように実装
- 日記の新規作成がデータベースに保存され、Timelineに即座に反映されるようになりました

## 変更内容

### components/DiaryEntry.tsx
- **'use client'ディレクティブを追加**
- **ユーザー取得**: `trpc.user.getByEmail`でsato@example.comのユーザーを取得
- **Mood一覧取得**: `trpc.mood.list`でMoodデータを取得
- **保存機能実装**: `trpc.diary.add.useMutation()`でバックエンドに保存
- **MoodID検索ロジック**: 選択されたcolorとiconから対応するmoodIdを検索
- **自動更新**: 保存成功時に`utils.diary.getAll.invalidate()`でTimelineを再取得
- **UI改善**:
  - ボタンに「保存中...」ローディング表示
  - 保存中はボタンを無効化
  - エラーメッセージ表示（赤色）
  - 成功メッセージ表示（緑色）

### app/page.tsx
- `handleSaveEntry`を`handleSaveSuccess`に変更
- MoodEntry型のパラメータを削除（DiaryEntry内部で完結）
- 保存成功時に選択色とアイコンをクリア

## データフロー
```
User fills form & clicks save
  ↓
Get user (trpc.user.getByEmail)
  ↓
Get moods (trpc.mood.list)
  ↓
Find moodId from color & icon
  ↓
trpc.diary.add.mutate({ title, content, moodId, userId, date })
  ↓
Save to database (Prisma)
  ↓
Invalidate timeline cache
  ↓
Timeline automatically refetches & displays new entry
```

## 技術的特徴
- **Optimistic Updates対応準備**: React Queryのinvalidateで自動再取得
- **型安全性**: tRPCによるエンドツーエンド型推論
- **エラーハンドリング**: mutation状態（pending, error, success）を適切に表示

## Test plan
- [ ] 開発サーバーを起動（`pnpm dev`）
- [ ] データベースにseedデータを投入（`pnpm seed`）
- [ ] 「書く」タブで気分を選択
- [ ] タイトルと内容を入力
- [ ] 「日記を保存」ボタンをクリック
- [ ] 「日記を保存しました！」メッセージが表示されることを確認
- [ ] 「一覧」タブに切り替えて新しい日記が表示されることを確認
- [ ] フォームがクリアされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)