### PR TITLE
feat: MoodCalendarをAPI連携化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -97,7 +97,6 @@ export default function Page() {
 
           <TabsContent value="calendar">
             <MoodCalendar
-              entries={[]}
               onEntryClick={handleEntryClick}
               onDayClick={handleDayClick}
             />


### PR DESCRIPTION
## Summary
- MoodCalendar.tsxをAPI経由でデータを取得して表示するように実装
- カレンダービューでデータベースに保存された日記が表示されるようになりました

## 変更内容

### components/MoodCalendar.tsx
- **'use client'ディレクティブを追加**
- **propsから`entries`を削除** - 内部でAPI取得に変更
- **ユーザー取得**: `trpc.user.getByEmail`でsato@example.comのユーザーを取得
- **日記データ取得**: `trpc.diary.getAll`でユーザーの日記データを取得
- **データ変換**: データベースから取得したデータをMoodEntry形式に変換
- **UI改善**:
  - ローディング状態表示（「読み込み中...」）
  - エラー状態表示（エラーメッセージ）
  - `enabled: !!user?.id`でuserIdが取得できるまでクエリを実行しない

### app/page.tsx
- MoodCalendarコンポーネントから`entries` propsを削除

## データフロー
```
User opens Calendar tab
  ↓
trpc.user.getByEmail({ email: "sato@example.com" })
  ↓
Get userId from user object
  ↓
trpc.diary.getAll({ userId })
  ↓
Convert database entries to MoodEntry format
  ↓
Display entries on calendar by date
  ↓
User clicks date → Show entries for that day
```

## 機能
- 月ごとのカレンダー表示
- 各日付に最大3つの日記アイコンを表示
- 4つ以上ある場合は「+N」で表示
- 日付クリックで詳細表示（1件の場合）または一覧表示（複数件の場合）
- 前月・次月・今日へのナビゲーション

## Test plan
- [ ] 開発サーバーを起動（`pnpm dev`）
- [ ] データベースにseedデータを投入（`pnpm seed`）
- [ ] 「カレンダー」タブをクリック
- [ ] 日記が保存されている日付にアイコンが表示されることを確認
- [ ] 日付をクリックして日記が表示されることを確認
- [ ] 前月・次月・今日ボタンが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)