### PR TITLE
feat: カレンダーのAPIインテグレーションとday.js対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@trpc/server": "^11.6.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.18",
     "lucide-react": "^0.544.0",
     "next": "15.5.4",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dayjs:
+        specifier: ^1.11.18
+        version: 1.11.18
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.0)
@@ -1518,6 +1521,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.18:
+    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -4027,6 +4033,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.18: {}
 
   debug@3.2.7:
     dependencies:


### PR DESCRIPTION
## Summary
- MoodCalendarコンポーネントをAPIからデータを取得するように変更
- day.jsライブラリを導入して日付処理を統一・改善
- カレンダーの日付とデータベースの日付が確実に一致するように実装を改善
- TypeScriptの型エラーを修正
- デバッグ用のconsole.logを削除してコードをクリーンアップ

## 主な変更点
### MoodCalendar.tsx
- `trpc.user.getByEmail` と `trpc.diary.getAll` を使用してデータを取得
- day.jsを使用した日付フォーマット処理（`YYYY-MM-DD`形式で統一）
- `entriesByDate` Mapの作成ロジックを簡素化
- カレンダー日付生成ロジックをday.jsで統一
- アイコンコンポーネントの型変換エラーを修正

### package.json / pnpm-lock.yaml
- day.jsライブラリを追加

## Test plan
- [x] カレンダータブで日記データが正しく表示されること
- [x] カレンダーの日付とデータベースの日付が一致していること
- [x] 月の切り替えが正常に動作すること
- [x] 「今日」ボタンが正常に動作すること
- [x] 日記エントリーをクリックすると詳細が表示されること
- [x] TypeScriptエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)